### PR TITLE
chore(linters): add govet to the enabled linters in golangci configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,7 @@ linters:
     - gomodguard
     - gosec
     - gosimple
+    - govet
     - importas
     - misspell
     - nakedret
@@ -29,7 +30,6 @@ linters:
     - usetesting
   disable:
     - errcheck
-    - govet
     - ineffassign
     - staticcheck
     - unused
@@ -52,6 +52,12 @@ linters-settings:
   gosec:
     excludes:
       - G115
+  govet:
+    disable:
+      - copylocks
+      - shadow
+      - testinggoroutine
+    enable-all: true
   perfsprint:
     # Optimizes even if it requires an int or uint type cast.
     int-conversion: true

--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -33,25 +33,25 @@ type TimesStat struct {
 }
 
 type InfoStat struct {
-	CPU        int32    `json:"cpu"`
+	PhysicalID string   `json:"physicalId"`
 	VendorID   string   `json:"vendorId"`
 	Family     string   `json:"family"`
 	Model      string   `json:"model"`
-	Stepping   int32    `json:"stepping"`
-	PhysicalID string   `json:"physicalId"`
 	CoreID     string   `json:"coreId"`
-	Cores      int32    `json:"cores"`
 	ModelName  string   `json:"modelName"`
-	Mhz        float64  `json:"mhz"`
-	CacheSize  int32    `json:"cacheSize"`
-	Flags      []string `json:"flags"`
 	Microcode  string   `json:"microcode"`
+	Flags      []string `json:"flags"`
+	Mhz        float64  `json:"mhz"`
+	Stepping   int32    `json:"stepping"`
+	Cores      int32    `json:"cores"`
+	CacheSize  int32    `json:"cacheSize"`
+	CPU        int32    `json:"cpu"`
 }
 
 type lastPercent struct {
-	sync.Mutex
 	lastCPUTimes    []TimesStat
 	lastPerCPUTimes []TimesStat
+	sync.Mutex
 }
 
 var (

--- a/cpu/cpu_windows.go
+++ b/cpu/cpu_windows.go
@@ -18,14 +18,14 @@ import (
 var procGetNativeSystemInfo = common.Modkernel32.NewProc("GetNativeSystemInfo")
 
 type win32_Processor struct { //nolint:revive //FIXME
-	Family                    uint16
+	ProcessorID               *string
+	Stepping                  *string
 	Manufacturer              string
 	Name                      string
 	NumberOfLogicalProcessors uint32
 	NumberOfCores             uint32
-	ProcessorID               *string
-	Stepping                  *string
 	MaxClockSpeed             uint32
+	Family                    uint16
 }
 
 // SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION

--- a/disk/disk.go
+++ b/disk/disk.go
@@ -15,14 +15,14 @@ type Warnings = common.Warnings
 type UsageStat struct {
 	Path              string  `json:"path"`
 	Fstype            string  `json:"fstype"`
+	UsedPercent       float64 `json:"usedPercent"`
+	InodesUsedPercent float64 `json:"inodesUsedPercent"`
 	Total             uint64  `json:"total"`
 	Free              uint64  `json:"free"`
 	Used              uint64  `json:"used"`
-	UsedPercent       float64 `json:"usedPercent"`
 	InodesTotal       uint64  `json:"inodesTotal"`
 	InodesUsed        uint64  `json:"inodesUsed"`
 	InodesFree        uint64  `json:"inodesFree"`
-	InodesUsedPercent float64 `json:"inodesUsedPercent"`
 }
 
 type PartitionStat struct {
@@ -33,6 +33,9 @@ type PartitionStat struct {
 }
 
 type IOCountersStat struct {
+	Name             string `json:"name"`
+	SerialNumber     string `json:"serialNumber"`
+	Label            string `json:"label"`
 	ReadCount        uint64 `json:"readCount"`
 	MergedReadCount  uint64 `json:"mergedReadCount"`
 	WriteCount       uint64 `json:"writeCount"`
@@ -44,9 +47,6 @@ type IOCountersStat struct {
 	IopsInProgress   uint64 `json:"iopsInProgress"`
 	IoTime           uint64 `json:"ioTime"`
 	WeightedIO       uint64 `json:"weightedIO"`
-	Name             string `json:"name"`
-	SerialNumber     string `json:"serialNumber"`
-	Label            string `json:"label"`
 }
 
 func (d UsageStat) String() string {

--- a/disk/disk_freebsd_amd64.go
+++ b/disk/disk_freebsd_amd64.go
@@ -31,29 +31,29 @@ type (
 )
 
 type devstat struct {
-	Sequence0     uint32
-	Allocated     int32
-	Start_count   uint32
-	End_count     uint32
-	Busy_from     bintime
-	Dev_links     _Ctype_struct___0
-	Device_number uint32
-	Device_name   [16]int8
-	Unit_number   int32
+	ID            *byte
+	Duration      [4]bintime
 	Bytes         [4]uint64
 	Operations    [4]uint64
-	Duration      [4]bintime
-	Busy_time     bintime
-	Creation_time bintime
-	Block_size    uint32
-	Pad_cgo_0     [4]byte
 	Tag_types     [3]uint64
+	Creation_time bintime
+	Busy_from     bintime
+	Busy_time     bintime
+	Dev_links     _Ctype_struct___0
+	Device_number uint32
+	Start_count   uint32
+	Sequence1     uint32
+	Sequence0     uint32
+	End_count     uint32
+	Block_size    uint32
+	Allocated     int32
+	Unit_number   int32
 	Flags         uint32
 	Device_type   uint32
 	Priority      uint32
+	Device_name   [16]int8
 	Pad_cgo_1     [4]byte
-	ID            *byte
-	Sequence1     uint32
+	Pad_cgo_0     [4]byte
 	Pad_cgo_2     [4]byte
 }
 

--- a/host/host.go
+++ b/host/host.go
@@ -20,9 +20,6 @@ var invoke common.Invoker = common.Invoke{}
 // This is not in the psutil but it useful.
 type InfoStat struct {
 	Hostname             string `json:"hostname"`
-	Uptime               uint64 `json:"uptime"`
-	BootTime             uint64 `json:"bootTime"`
-	Procs                uint64 `json:"procs"`           // number of processes
 	OS                   string `json:"os"`              // ex: freebsd, linux
 	Platform             string `json:"platform"`        // ex: ubuntu, linuxmint
 	PlatformFamily       string `json:"platformFamily"`  // ex: debian, rhel
@@ -32,6 +29,9 @@ type InfoStat struct {
 	VirtualizationSystem string `json:"virtualizationSystem"`
 	VirtualizationRole   string `json:"virtualizationRole"` // guest or host
 	HostID               string `json:"hostId"`             // ex: uuid
+	Uptime               uint64 `json:"uptime"`
+	BootTime             uint64 `json:"bootTime"`
+	Procs                uint64 `json:"procs"` // number of processes
 }
 
 type UserStat struct {

--- a/host/host_freebsd_amd64.go
+++ b/host/host_freebsd_amd64.go
@@ -28,11 +28,11 @@ type Utmp struct {
 }
 
 type Utmpx struct {
-	Type uint8
 	Tv   uint64
-	Id   [8]int8
 	Pid  uint32
+	Host [128]int8
 	User [32]int8
 	Line [16]int8
-	Host [128]int8
+	Id   [8]int8
+	Type uint8
 }

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -68,8 +68,8 @@ func (i Invoke) CommandWithContext(ctx context.Context, name string, arg ...stri
 }
 
 type FakeInvoke struct {
-	Suffix string // Suffix species expected file name suffix such as "fail"
 	Error  error  // If Error specified, return the error.
+	Suffix string // Suffix species expected file name suffix such as "fail"
 }
 
 // Command in FakeInvoke returns from expected file if exists.

--- a/internal/common/common_darwin.go
+++ b/internal/common/common_darwin.go
@@ -70,9 +70,9 @@ func CallSyscall(mib []int32) ([]byte, uint64, error) {
 
 // Library represents a dynamic library loaded by purego.
 type Library struct {
-	addr  uintptr
-	path  string
 	close func()
+	path  string
+	addr  uintptr
 }
 
 // library paths
@@ -281,9 +281,9 @@ const (
 
 // SMC represents a SMC instance.
 type SMC struct {
+	callStruct IOConnectCallStructMethodFunc
 	lib        *Library
 	conn       uint32
-	callStruct IOConnectCallStructMethodFunc
 }
 
 const ioServiceSMC = "AppleSMC"

--- a/mem/mem_freebsd.go
+++ b/mem/mem_freebsd.go
@@ -93,8 +93,8 @@ const (
 
 // Types from vm/vm_param.h
 type xswdev struct {
-	Version uint32 // Version is the version
 	Dev     uint64 // Dev is the device identifier
+	Version uint32 // Version is the version
 	Flags   int32  // Flags is the swap flags applied to the device
 	NBlks   int32  // NBlks is the total number of blocks
 	Used    int32  // Used is the number of blocks used

--- a/mem/mem_linux_test.go
+++ b/mem/mem_linux_test.go
@@ -26,11 +26,12 @@ func TestExVirtualMemory(t *testing.T) {
 }
 
 var virtualMemoryTests = []struct {
-	mockedRootFS string
 	stat         *VirtualMemoryStat
+	mockedRootFS string
 }{
 	{
-		"intelcorei5", &VirtualMemoryStat{
+		mockedRootFS: "intelcorei5",
+		stat: &VirtualMemoryStat{
 			Total:          16502300672,
 			Available:      11495358464,
 			Used:           3437277184,
@@ -71,7 +72,8 @@ var virtualMemoryTests = []struct {
 		},
 	},
 	{
-		"issue1002", &VirtualMemoryStat{
+		mockedRootFS: "issue1002",
+		stat: &VirtualMemoryStat{
 			Total:          260579328,
 			Available:      215199744,
 			Used:           34328576,
@@ -112,7 +114,8 @@ var virtualMemoryTests = []struct {
 		},
 	},
 	{
-		"anonhugepages", &VirtualMemoryStat{
+		mockedRootFS: "anonhugepages",
+		stat: &VirtualMemoryStat{
 			Total:         260799420 * 1024,
 			Available:     127880216 * 1024,
 			Free:          119443248 * 1024,

--- a/mem/mem_plan9_test.go
+++ b/mem/mem_plan9_test.go
@@ -14,11 +14,12 @@ import (
 )
 
 var virtualMemoryTests = []struct {
-	mockedRootFS string
 	stat         *VirtualMemoryStat
+	mockedRootFS string
 }{
 	{
-		"swap", &VirtualMemoryStat{
+		mockedRootFS: "swap",
+		stat: &VirtualMemoryStat{
 			Total:       1071185920,
 			Available:   808370176,
 			Used:        11436032,
@@ -44,11 +45,12 @@ func TestVirtualMemoryPlan9(t *testing.T) {
 }
 
 var swapMemoryTests = []struct {
-	mockedRootFS string
 	swap         *SwapMemoryStat
+	mockedRootFS string
 }{
 	{
-		"swap", &SwapMemoryStat{
+		mockedRootFS: "swap",
+		swap: &SwapMemoryStat{
 			Total: 655360000,
 			Used:  0,
 			Free:  655360000,

--- a/mem/mem_windows.go
+++ b/mem/mem_windows.go
@@ -57,17 +57,17 @@ func VirtualMemoryWithContext(_ context.Context) (*VirtualMemoryStat, error) {
 }
 
 type performanceInformation struct {
-	cb                uint32
-	commitTotal       uint64
+	systemCache       uint64
+	pageSize          uint64
 	commitLimit       uint64
 	commitPeak        uint64
 	physicalTotal     uint64
 	physicalAvailable uint64
-	systemCache       uint64
-	kernelTotal       uint64
 	kernelPaged       uint64
+	kernelTotal       uint64
+	commitTotal       uint64
 	kernelNonpaged    uint64
-	pageSize          uint64
+	cb                uint32
 	handleCount       uint32
 	processCount      uint32
 	threadCount       uint32

--- a/net/net.go
+++ b/net/net.go
@@ -32,20 +32,20 @@ type Addr struct {
 }
 
 type ConnectionStat struct {
+	Status string  `json:"status"`
+	Laddr  Addr    `json:"localaddr"`
+	Raddr  Addr    `json:"remoteaddr"`
+	Uids   []int32 `json:"uids"`
 	Fd     uint32  `json:"fd"`
 	Family uint32  `json:"family"`
 	Type   uint32  `json:"type"`
-	Laddr  Addr    `json:"localaddr"`
-	Raddr  Addr    `json:"remoteaddr"`
-	Status string  `json:"status"`
-	Uids   []int32 `json:"uids"`
 	Pid    int32   `json:"pid"`
 }
 
 // System wide stats about different network protocols
 type ProtoCountersStat struct {
-	Protocol string           `json:"protocol"`
 	Stats    map[string]int64 `json:"stats"`
+	Protocol string           `json:"protocol"`
 }
 
 // NetInterfaceAddr is designed for represent interface addresses
@@ -57,12 +57,12 @@ type InterfaceAddr struct {
 type InterfaceAddrList []InterfaceAddr
 
 type InterfaceStat struct {
-	Index        int               `json:"index"`
-	MTU          int               `json:"mtu"`          // maximum transmission unit
 	Name         string            `json:"name"`         // e.g., "en0", "lo0", "eth0.100"
 	HardwareAddr string            `json:"hardwareAddr"` // IEEE MAC-48, EUI-48 and EUI-64 form
-	Flags        []string          `json:"flags"`        // e.g., FlagUp, FlagLoopback, FlagMulticast
 	Addrs        InterfaceAddrList `json:"addrs"`
+	Flags        []string          `json:"flags"` // e.g., FlagUp, FlagLoopback, FlagMulticast
+	Index        int               `json:"index"`
+	MTU          int               `json:"mtu"` // maximum transmission unit
 }
 
 // InterfaceStatList is a list of InterfaceStat

--- a/net/net_linux.go
+++ b/net/net_linux.go
@@ -286,9 +286,9 @@ var tcpStatuses = map[string]string{
 }
 
 type netConnectionKindType struct {
+	filename string
 	family   uint32
 	sockType uint32
-	filename string
 }
 
 var kindTCP4 = netConnectionKindType{
@@ -340,15 +340,15 @@ type inodeMap struct {
 }
 
 type connTmp struct {
+	status   string
+	path     string
+	laddr    Addr
+	raddr    Addr
 	fd       uint32
 	family   uint32
 	sockType uint32
-	laddr    Addr
-	raddr    Addr
-	status   string
 	pid      int32
 	boundPid int32
-	path     string
 }
 
 func ConnectionsWithContext(ctx context.Context, kind string) ([]ConnectionStat, error) {
@@ -543,8 +543,8 @@ func PidsWithContext(ctx context.Context) ([]int32, error) {
 // FIXME: Import process occures import cycle.
 // see remarks on pids()
 type process struct {
-	Pid  int32 `json:"pid"`
 	uids []int32
+	Pid  int32 `json:"pid"`
 }
 
 // Uids returns user ids of the process as a slice of the int

--- a/net/net_windows.go
+++ b/net/net_windows.go
@@ -37,9 +37,9 @@ const (
 )
 
 type netConnectionKindType struct {
+	filename string
 	family   uint32
 	sockType uint32
-	filename string
 }
 
 var kindTCP4 = netConnectionKindType{

--- a/process/process.go
+++ b/process/process.go
@@ -24,24 +24,22 @@ var (
 )
 
 type Process struct {
-	Pid            int32 `json:"pid"`
-	name           string
-	status         string
-	parent         int32
-	parentMutex    sync.RWMutex // for windows ppid cache
+	lastCPUTime    time.Time
 	numCtxSwitches *NumCtxSwitchesStat
+	sigInfo        *SignalInfoStat
+	memInfo        *MemoryInfoStat
+	lastCPUTimes   *cpu.TimesStat
+	status         string
+	name           string
 	uids           []uint32
 	gids           []uint32
 	groups         []uint32
-	numThreads     int32
-	memInfo        *MemoryInfoStat
-	sigInfo        *SignalInfoStat
 	createTime     int64
-
-	lastCPUTimes *cpu.TimesStat
-	lastCPUTime  time.Time
-
-	tgid int32
+	parentMutex    sync.RWMutex // for windows ppid cache
+	numThreads     int32
+	tgid           int32
+	parent         int32
+	Pid            int32 `json:"pid"`
 }
 
 // Process status

--- a/sensors/sensors_windows.go
+++ b/sensors/sensors_windows.go
@@ -13,10 +13,10 @@ import (
 )
 
 type msAcpi_ThermalZoneTemperature struct { //nolint:revive //FIXME
-	Active             bool
+	InstanceName       string
 	CriticalTripPoint  uint32
 	CurrentTemperature uint32
-	InstanceName       string
+	Active             bool
 }
 
 func TemperaturesWithContext(ctx context.Context) ([]TemperatureStat, error) {

--- a/winservices/winservices.go
+++ b/winservices/winservices.go
@@ -15,18 +15,18 @@ import (
 
 // Service represent a windows service.
 type Service struct {
+	srv    *mgr.Service
 	Name   string
 	Config mgr.Config
 	Status ServiceStatus
-	srv    *mgr.Service
 }
 
 // ServiceStatus combines State and Accepted commands to fully describe running service.
 type ServiceStatus struct {
-	State         svc.State
-	Accepts       svc.Accepted
 	Pid           uint32
 	Win32ExitCode uint32
+	State         svc.State
+	Accepts       svc.Accepted
 }
 
 // NewService create and return a windows Service


### PR DESCRIPTION
#### Description
This pull request updates the GolangCI configuration to enable the `govet` linter, improving code quality by catching potential issues during static analysis. The changes include:

- Adding `govet` to the list of enabled linters in the GolangCI configuration.
- Fixing code issues flagged by `govet` across multiple packages (disk, mem, process, net, cpu, host, sensors, winservices).
- Refactoring and minor adjustments to ensure compliance with the new linter rules.

These changes enhance code maintainability and align the project with best practices.